### PR TITLE
Add note for Linux users regarding certs permissions

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -7,7 +7,7 @@ This [Docker Compose](.compose.yaml) file spins up a local environment for testi
 
 ## Prerequisites
 
-1. The agent communicates with the source and destinations clusters over TLS enabled interfaces, so before starting the containers, run [generate-certs.sh](./generate-certs.sh) to create the necessary certificates. The resulting `./certs` directory is mounted on the containers in the [compose](./compose.yaml) configuration
+1. The agent communicates with the source and destinations clusters over TLS enabled interfaces, so before starting the containers, run [generate-certs.sh](./generate-certs.sh) to create the necessary certificates. The resulting `./certs` directory is mounted on the containers in the [compose](./compose.yaml) configuration. *Note: On Linux, it may be necessary to run `sudo chmod -R 777 certs` to ensure this directory can be read by the container user `redpanda`.*
 2. Run the [build.sh](./build.sh) script to compile the agent for the Linux-based container
 
 ## Start the containers


### PR DESCRIPTION
I ran into this issue again when reviewing a recent PR, forgetting initially to change the permissions of the `certs` folder after generating it. This PR adds a note about how to resolve this.