### PR TITLE
Maximum Kafka protocol version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ redpanda-edge-agent*
 # TLS certificates
 *.crt
 *.key
+*.jks
+*.p12

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ destination:
     name: "destination"
     # List of Redpanda nodes
     bootstrap_servers: 127.0.0.1:29092
+    # Maximum Kafka protocol version. E.g. "3.0.0"
+    max_version: ""
     # List of topics to pull from the destination cluster (to create a
     # bidirectional flow).
     topics:

--- a/agent/config.go
+++ b/agent/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/knadh/koanf"
@@ -10,6 +11,7 @@ import (
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl/aws"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
@@ -148,6 +150,34 @@ func SASLOpt(config *SASLConfig, opts []kgo.Opt) []kgo.Opt {
 		default:
 			log.Fatalf("Unrecognized sasl method: %s", method)
 		}
+	}
+	return opts
+}
+
+// Set the maximum Kafka protocol version to try
+func MaxVersionOpt(version string, opts []kgo.Opt) []kgo.Opt {
+	ver := strings.ToLower(version)
+	ver = strings.ReplaceAll(ver, "v", "")
+	ver = strings.ReplaceAll(ver, ".", "")
+	ver = strings.ReplaceAll(ver, "_", "")
+	verNum, _ := strconv.Atoi(ver)
+	switch verNum {
+	case 330:
+		opts = append(opts, kgo.MaxVersions(kversion.V3_3_0()))
+	case 320:
+		opts = append(opts, kgo.MaxVersions(kversion.V3_2_0()))
+	case 310:
+		opts = append(opts, kgo.MaxVersions(kversion.V3_1_0()))
+	case 300:
+		opts = append(opts, kgo.MaxVersions(kversion.V3_0_0()))
+	case 280:
+		opts = append(opts, kgo.MaxVersions(kversion.V2_8_0()))
+	case 270:
+		opts = append(opts, kgo.MaxVersions(kversion.V2_7_0()))
+	case 260:
+		opts = append(opts, kgo.MaxVersions(kversion.V2_6_0()))
+	default:
+		opts = append(opts, kgo.MaxVersions(kversion.Stable()))
 	}
 	return opts
 }

--- a/agent/main.go
+++ b/agent/main.go
@@ -91,6 +91,10 @@ func initClient(rp *Redpanda, mutex *sync.Once, pathPrefix string) {
 				kgo.DisableAutoCommit(),
 				kgo.BlockRebalanceOnPoll())
 		}
+		maxVersionPath := fmt.Sprintf("%s.max_version", pathPrefix)
+		if config.Exists(maxVersionPath) {
+			opts = MaxVersionOpt(config.String(maxVersionPath), opts)
+		}
 		tlsPath := fmt.Sprintf("%s.tls", pathPrefix)
 		if config.Exists(tlsPath) {
 			tlsConfig := TLSConfig{}

--- a/example/agent.yaml
+++ b/example/agent.yaml
@@ -1,7 +1,7 @@
 create_topics: true
 source:
   name: "source"
-  bootstrap_servers: 172.24.1.10:9092 # use secured internal interface  
+  bootstrap_servers: 172.24.1.10:9092 # use secured internal interface
   # List of outbound topics to push from source to destination
   topics:
     - telemetry1
@@ -13,7 +13,8 @@ source:
     ca_cert: "/etc/redpanda/certs/ca.crt"
 destination:
   name: "destination"
-  bootstrap_servers: 172.24.1.20:9092 # use secured internal interface  
+  bootstrap_servers: 172.24.1.20:9092 # use secured internal interface
+  max_version: "3.0.0" # maximum kafka protocol version
   # List of inbound topics to pull from destination to source
   topics:
     - config1

--- a/example/compose-kafka.yaml
+++ b/example/compose-kafka.yaml
@@ -1,0 +1,75 @@
+networks:
+  redpanda_network:
+    driver: bridge
+    ipam:
+      config:
+      - subnet: "172.24.1.0/24"
+        gateway: "172.24.1.1"
+services:
+  redpanda_source:
+    image: docker.vectorized.io/vectorized/redpanda:v22.2.7
+    container_name: redpanda_source
+    command:
+      - redpanda
+      - start
+      - --kafka-addr
+      - internal://0.0.0.0:9092,external://172.24.1.10:19092
+      - --advertise-kafka-addr
+      - internal://172.24.1.10:9092,external://127.0.0.1:19092
+      - --overprovisioned
+      - --check=false
+      - --set redpanda.auto_create_topics_enabled=true
+      - "--set redpanda.kafka_api_tls={\
+          'name':'internal','enabled':true,'require_client_auth':true,\
+          'cert_file':'/etc/redpanda/certs/src.crt',\
+          'key_file':'/etc/redpanda/certs/src.key',\
+          'truststore_file':'/etc/redpanda/certs/ca.crt'}"
+      - "--set redpanda.admin_api_tls={\
+          'name':'internal','enabled':true,'require_client_auth':true,\
+          'cert_file':'/etc/redpanda/certs/src.crt',\
+          'key_file':'/etc/redpanda/certs/src.key',\
+          'truststore_file':'/etc/redpanda/certs/ca.crt'}"
+    networks:
+      redpanda_network:
+        ipv4_address: "172.24.1.10"
+    volumes:
+      - ./certs:/etc/redpanda/certs
+      - ./redpanda-edge-agent:/usr/local/bin/redpanda-edge-agent
+      - ./agent.yaml:/etc/redpanda/agent.yaml
+      - ./supervisor.conf:/etc/supervisord.conf
+    ports:
+      - "19092:19092"
+  zookeeper:
+    image: bitnami/zookeeper:3.8.0
+    container_name: zookeeper
+    networks:
+      redpanda_network:
+        ipv4_address: "172.24.1.30"
+    ports:
+      - "2181:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: bitnami/kafka:3.3.1
+    container_name: kafka_destination
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=172.24.1.30:2181
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:29092,INTERNAL://:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,INTERNAL:SSL
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:29092,INTERNAL://172.24.1.20:9092
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CERTIFICATE_PASSWORD=apache
+      - KAFKA_CFG_INTER_BROKER_PROTOCOL_VERSION=2.6
+      - BITNAMI_DEBUG=true
+    networks:
+      redpanda_network:
+        ipv4_address: "172.24.1.20"
+    volumes:
+      - "./certs/kafka.keystore.jks:/opt/bitnami/kafka/config/certs/kafka.keystore.jks"
+      - "./certs/kafka.truststore.jks:/opt/bitnami/kafka/config/certs/kafka.truststore.jks"
+    ports:
+      - "29092:29092"
+    depends_on:
+      - zookeeper

--- a/example/generate-certs.sh
+++ b/example/generate-certs.sh
@@ -115,6 +115,18 @@ openssl ca \
 -subj "/O=redpanda/CN=redpanda_destination" \
 -batch
 
+# Generate Java keystores for a Kafka destination
+openssl pkcs12 -export -inkey $CERTS_DIR/dst.key -in $CERTS_DIR/dst.crt -out $CERTS_DIR/dst.p12 -password pass:apache
+keytool -importkeystore \
+-srckeystore $CERTS_DIR/dst.p12 \
+-srcstoretype pkcs12 \
+-srcstorepass apache \
+-destkeystore $CERTS_DIR/kafka.keystore.jks \
+-deststorepass apache \
+-destkeypass apache
+
+keytool -keystore $CERTS_DIR/kafka.truststore.jks -alias CARoot -import -file $CERTS_DIR/ca.crt -noprompt -storepass apache
+
 # Generate RSA private key for the agent
 openssl genrsa -out $CERTS_DIR/agent.key 2048
 chmod 400 $CERTS_DIR/agent.key

--- a/example/supervisor.conf
+++ b/example/supervisor.conf
@@ -5,7 +5,7 @@ nodaemon=false
 user=redpanda
 identifier=supervisord
 [program:edge-agent]
-command=bash -c "sleep 5 && redpanda-edge-agent -config /etc/redpanda/agent.yaml -loglevel debug"
+command=bash -c "sleep 10 && redpanda-edge-agent -config /etc/redpanda/agent.yaml -loglevel debug"
 directory=/var/lib/redpanda
 redirect_stderr=true
 stdout_logfile=/var/lib/redpanda/data/agent.log


### PR DESCRIPTION
This PR provides the ability to set the maximum Kafka protocol version.

It is not always possible to control the destination cluster's configuration, and if the protocol version differs from what the client expects then it can cause producer and consumer errors in the agent. See [franz-go/issues/295](https://github.com/twmb/franz-go/issues/295) for an example.

This change allows the `source` and `destination` clusters maximum Kafka protocol to be set:
```yaml
destination:
  ...
  max_version: "3.0.0" # maximum kafka protocol version
```