### PR TITLE
[Proof-of-concept] Strict topic priority for bandwidth-constrained situations

### DIFF
--- a/agent/agent.yaml
+++ b/agent/agent.yaml
@@ -1,0 +1,11 @@
+create_topics: true
+source:
+    name: "source"
+    bootstrap_servers: 127.0.0.1:19092
+    topics:
+        - owlshop-frontend-events
+        - owlshop-orders
+
+destination:
+    name: "destination"
+    bootstrap_servers: 127.0.0.1:29092

--- a/agent/config.go
+++ b/agent/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
@@ -127,7 +128,7 @@ var defaultID = func() string {
 		log.Fatalf("Unable to get hostname from kernel. Set Id in config")
 	}
 	log.Debugf("Hostname: %s", hostname)
-	return hostname
+	return hostname + uuid.NewString()
 }()
 
 // Initialize the agent configuration from the provided .yaml file

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,54 @@
+services:
+  redpanda1:
+    image: docker.redpanda.com/redpandadata/redpanda:v23.3.1
+    hostname: redpanda1
+    command:
+      - redpanda
+      - start
+      - --smp 1
+      - --overprovisioned
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:19092
+      - --advertise-kafka-addr
+      - PLAINTEXT://redpanda1:9092,OUTSIDE://localhost:19092
+      - --rpc-addr 0.0.0.0:33145
+      - --advertise-rpc-addr redpanda1:33145
+    ports:
+      - 19092:19092 # Kafka API port
+
+  redpanda2:
+    image: docker.redpanda.com/redpandadata/redpanda:v23.3.1
+    # container_name: redpanda2
+    command:
+      - redpanda
+      - start
+      - --smp 1
+      - --overprovisioned
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:29092
+      - --advertise-kafka-addr
+      - PLAINTEXT://redpanda2:9092,OUTSIDE://localhost:29092
+      - --rpc-addr 0.0.0.0:33145
+      - --advertise-rpc-addr redpanda2:33145
+    ports:
+      - 29092:29092 # Kafka API port
+  
+  owl-shop:
+    image: golang:bookworm
+    environment:
+      - KAFKA_BROKERS=redpanda1:9092
+      - SHOP_TOPICREPLICATIONFACTOR=1
+      - SHOP_REQUESTRATE=1000
+      # - SHOP_TRAFFIC_INTERVAL_DURATION=1s
+    command:
+      - bash
+      - -c
+      - |
+        git clone https://github.com/cloudhut/owl-shop.git --depth 1
+        cd owl-shop
+        go run cmd/main.go
+      - --
+    depends_on:
+      - redpanda1
+    volumes:
+      - ./cache/go/pkg/mod:/go/pkg/mod

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.13.0/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=


### PR DESCRIPTION
Not meant for merging or production (yet?), just as a potential idea.

I hacked up the client to (1) prefer sending messages from topics in higher priority groups, over messages from topics in lower priority groups and (2) consume messages continuously in a separate goroutine to keep our local buffers full. It's super messy and has some config hard-coded in but shows that the basic algorithm works.

Why? This was an ask for use cases where bandwidth can be limited, and you want to be able to prioritize delivery/replication of important messages back to the centralized cluster until you get more bandwidth or the production of important messages slows down.